### PR TITLE
[P20-1696] [kubernetes] Removing deprecated kube-apiserver flag insecure-port

### DIFF
--- a/providers/amazon-spot/images/ivy-kubernetes-1.21/packer.env
+++ b/providers/amazon-spot/images/ivy-kubernetes-1.21/packer.env
@@ -1,1 +1,1 @@
-export PACKER_SPOT_INSTANCE_TYPE='g4dn.2xlarge'
+export PACKER_SPOT_INSTANCE_TYPE='g4dn.xlarge'

--- a/providers/amazon-spot/images/ivy-kubernetes-1.22/packer.env
+++ b/providers/amazon-spot/images/ivy-kubernetes-1.22/packer.env
@@ -1,1 +1,1 @@
-export PACKER_SPOT_INSTANCE_TYPE='g4dn.2xlarge'
+export PACKER_SPOT_INSTANCE_TYPE='g4dn.xlarge'

--- a/roles/kubernetes/files/etc/systemd/system/kube-apiserver.service
+++ b/roles/kubernetes/files/etc/systemd/system/kube-apiserver.service
@@ -33,7 +33,6 @@ ExecStart=/usr/bin/kube-apiserver \
     --etcd-servers=https://${ENDPOINT}:2379 \
     --goaway-chance=${GOAWAY_CHANCE} \
     --secure-port=443 \
-    --insecure-port=0 \
     --client-ca-file=${KUBE_CA} \
     --service-account-issuer=https://${ENDPOINT}:443 \
     --service-account-key-file=${SERVICE_ACCOUNT_PUB} \

--- a/roles/kubernetes/files/etc/systemd/system/kubelet.service.d/10-kubelet-common.conf
+++ b/roles/kubernetes/files/etc/systemd/system/kubelet.service.d/10-kubelet-common.conf
@@ -18,6 +18,7 @@ ExecStartPre=/opt/ivy/kubelet-update-config.sh \
 ExecStart=
 ExecStart=/usr/bin/kubelet \
     --container-runtime docker \
+    --network-plugin cni \
     --kubeconfig $KUBELET_KUBECONFIG \
     --config $KUBELET_CONFIG \
     --node-labels $DEFAULT_NODE_LABELS \

--- a/roles/kubernetes/files/etc/systemd/system/kubelet.service.d/10-kubelet-common.conf
+++ b/roles/kubernetes/files/etc/systemd/system/kubelet.service.d/10-kubelet-common.conf
@@ -10,16 +10,16 @@ EnvironmentFile=-/var/lib/kubelet/ivy-provider-id
 ExecStartPre=/sbin/iptables -P FORWARD ACCEPT -w 5
 ExecStartPre=/opt/ivy/kubelet-default-labels.sh /var/lib/kubelet/ivy-node-labels
 ExecStartPre=/opt/ivy/kubelet-provider-id.sh /var/lib/kubelet/ivy-provider-id
+ExecStartPre=/opt/ivy/kubelet-update-config.sh \
+    --cluster-domain $CLUSTER_DOMAIN \
+    --cluster-dns $CLUSTER_DNS \
+    --provider-id $PROVIDER_ID
 # must blank out the ExecStart to zero the list
 ExecStart=
 ExecStart=/usr/bin/kubelet \
     --container-runtime docker \
-    --network-plugin cni \
     --kubeconfig $KUBELET_KUBECONFIG \
     --config $KUBELET_CONFIG \
-    --cluster-domain $CLUSTER_DOMAIN \
-    --cluster-dns $CLUSTER_DNS \
     --node-labels $DEFAULT_NODE_LABELS \
     --node-labels $EXTRA_NODE_LABELS \
-    --provider-id $PROVIDER_ID \
     $KUBELET_EXTRA_ARGS

--- a/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
+++ b/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC1091
+. /opt/ivy/bash_functions.sh
+
+THIS_SCRIPT=$(basename "${0}")
+PADDING=$(printf %-${#THIS_SCRIPT}s " ")
+
+function usage () {
+  echo "Usage:"
+  echo "${THIS_SCRIPT} -c,--config <kubelet config file to update, default: /etc/kubernetes/kubelet/config.yaml>"
+  echo "${PADDING} --cluster-domain <clusterDomain is the DNS domain for this cluster>"
+  echo "${PADDING} --cluster-dns <clusterDNS IP addresses for the cluster DNS server, repeat this parameter per IP>"
+  echo "${PADDING} --provider-id <providerID, if set, sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node>"
+  echo
+  echo "Update kubelet config file"
+  exit
+}
+
+declare -a CLUSTER_DNS=()
+KUBELET_KUBECONFIG='/etc/kubernetes/kubelet/config.yaml'
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+      -c|--config)
+        KUBELET_KUBECONFIG="${2}"
+        shift # past argument
+        shift # past value
+        ;;
+      --cluster-domain)
+        CLUSTER_DOMAIN="${2}"
+        shift # past argument
+        shift # past value
+        ;;
+      --cluster-dns)
+        CLUSTER_DNS+=("${2}")
+        shift # past argument
+        shift # past value
+        ;;
+      --provider-id)
+        PROVIDER_ID="${2}"
+        shift # past argument
+        shift # past value
+        ;;
+      -*)
+        echo "Unknown option ${1}"
+        usage
+        ;;
+  esac
+done
+
+if [[ -z ${CLUSTER_DOMAIN:-""} ]] || [[ -z ${CLUSTER_DNS:-""} ]] || [[ -z ${PROVIDER_ID:-""} ]]; then
+  usage
+fi
+
+yq e -i ".clusterDomain = \"${CLUSTER_DOMAIN}\"" "${KUBELET_KUBECONFIG}"
+
+for dns in "${CLUSTER_DNS[@]}"; do
+  yq e -i ".clusterDNS += \"${dns}\"" "${KUBELET_KUBECONFIG}"
+done
+
+yq e -i ".providerID = \"${PROVIDER_ID}\"" "${KUBELET_KUBECONFIG}"

--- a/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
+++ b/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
@@ -55,8 +55,8 @@ fi
 
 yq e -i ".clusterDomain = \"${CLUSTER_DOMAIN}\"" "${KUBELET_KUBECONFIG}"
 
-for dns in "${CLUSTER_DNS[@]}"; do
-  yq e -i ".clusterDNS += \"${dns}\"" "${KUBELET_KUBECONFIG}"
+for i in "${!CLUSTER_DNS[@]}"; do
+  yq e -i ".clusterDNS[${i}] = \"${CLUSTER_DNS[${i}]}\"" "${KUBELET_KUBECONFIG}"
 done
 
 yq e -i ".providerID = \"${PROVIDER_ID}\"" "${KUBELET_KUBECONFIG}"

--- a/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
+++ b/roles/kubernetes/files/opt/ivy/kubelet-update-config.sh
@@ -10,9 +10,9 @@ PADDING=$(printf %-${#THIS_SCRIPT}s " ")
 function usage () {
   echo "Usage:"
   echo "${THIS_SCRIPT} -c,--config <kubelet config file to update, default: /etc/kubernetes/kubelet/config.yaml>"
-  echo "${PADDING} --cluster-domain <clusterDomain is the DNS domain for this cluster>"
-  echo "${PADDING} --cluster-dns <clusterDNS IP addresses for the cluster DNS server, repeat this parameter per IP>"
-  echo "${PADDING} --provider-id <providerID, if set, sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node>"
+  echo "${PADDING} --cluster-domain <clusterDomain is the DNS domain for this cluster. REQUIRED>"
+  echo "${PADDING} --cluster-dns <clusterDNS IP addresses for the cluster DNS server, repeat this parameter per IP. REQUIRED>"
+  echo "${PADDING} --provider-id <providerID, if set, sets the unique ID of the instance that an external provider (i.e. cloudprovider) can use to identify a specific node. REQUIRED>"
   echo
   echo "Update kubelet config file"
   exit

--- a/roles/kubernetes/tasks/main.yml
+++ b/roles/kubernetes/tasks/main.yml
@@ -66,6 +66,7 @@
     - etcdctl.sh
     - kubelet-default-labels.sh
     - kubelet-provider-id.sh
+    - kubelet-update-config.sh
     - k8s-check.sh
 
 - name: download k8s server components


### PR DESCRIPTION
Adding script /opt/ivy/kubelet-update-config.sh that will update /etc/kubernetes/kubelet/config.yaml
with cluster-domain, cluster-dns and provider-id since these flags have been deprecated from kubelet
Removing deprecated kubelet flag network-plugin

### About `--network-plugin cni`

Even when the flag has been deprecated since we are still using `--container-runtime docker` I still need to set this flag `--network-plugin cni`

### Related PRs

- https://github.com/Over-haul/infra-thunder/pull/44