### PR TITLE
[P20-2311] [system-base] Added support for specifying datadog site

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,11 +13,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
       - name: Install shellcheck
         shell: bash
         run: |
-          wget -qO- https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz | tar -xJf -
-          cp shellcheck-v0.8.0/shellcheck /usr/local/bin
-      - name: Run pre-commit
-        uses: pre-commit/action@v2.0.3
+          wget -qO- https://github.com/koalaman/shellcheck/releases/download/v0.9.0/shellcheck-v0.9.0.linux.x86_64.tar.xz | tar -xJf -
+          cp shellcheck-v0.9.0/shellcheck /usr/local/bin
+      - name: run pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: detect-private-key
@@ -14,11 +14,11 @@ repos:
       - id: check-yaml
       - id: requirements-txt-fixer
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
+    rev: v0.1.22
     hooks:
       - id: shellcheck
         exclude: '.*\.sh\.j2'
   - repo: https://github.com/igorshubovych/markdownlint-cli.git
-    rev: v0.31.1
+    rev: v0.35.0
     hooks:
       - id: markdownlint-fix

--- a/roles/cassandra/files/cassandrabackups.sh
+++ b/roles/cassandra/files/cassandrabackups.sh
@@ -50,6 +50,7 @@ function show_help() {
 }
 
 function clearsnapshot() {
+  # shellcheck disable=SC2317
   nodetool clearsnapshot -t "${SNAP_NAME}"
 }
 

--- a/roles/system-base/files/opt/ivy/bash_functions.sh
+++ b/roles/system-base/files/opt/ivy/bash_functions.sh
@@ -110,9 +110,11 @@ function get_capped_ram_mb_by_percent() {
 
 function set_datadog_key() {
   local DD_API_KEY="${1}"
-  local DD_CONFIG_FILE="${2:-/etc/datadog-agent/datadog.yaml}"
+  local DD_SITE="${2:-datadoghq.com}"
+  local DD_CONFIG_FILE="${3:-/etc/datadog-agent/datadog.yaml}"
   cat <<EOF > "${DD_CONFIG_FILE}"
 api_key: ${DD_API_KEY}
+site: ${DD_SITE}
 bind_host: 0.0.0.0
 EOF
 }

--- a/scripts/lib/strict-mode-fail
+++ b/scripts/lib/strict-mode-fail
@@ -32,7 +32,7 @@ strictModeFail() (
         if [[ ${#BASH_ARGC[@]} -gt ${i} ]] && [[ ${#BASH_ARGV[@]} -ge $(( nextArg + BASH_ARGC[i] )) ]]; then
             for (( argsLeft = BASH_ARGC[i]; argsLeft; --argsLeft )); do
                 # Note: this reverses the order on purpose
-                argsList[${argsLeft}]=${BASH_ARGV[nextArg]}
+                argsList[argsLeft]=${BASH_ARGV[nextArg]}
                 (( nextArg ++ ))
             done
 


### PR DESCRIPTION
[P20-2311] [GitHub Actions] Updated pre-commit to hooks:
 - https://github.com/pre-commit/pre-commit-hooks to `4.4.0`
 - https://github.com/gruntwork-io/pre-commit to `v0.1.22`
 - https://github.com/igorshubovych/markdownlint-cli.git to `v0.35.0`