### PR TITLE
[P20-2311] Bumping Amazon Linux 2 AMI to version `20230628.0`

### DIFF
--- a/providers/amazon-spot/images/default/packer.env
+++ b/providers/amazon-spot/images/default/packer.env
@@ -1,7 +1,7 @@
 # Defaults for all images
 # Override these with a packer.env file
 export PACKER_CONFIG=amazon-spot.json
-export PACKER_SOURCE_IMAGE_NAME='amzn2-ami-hvm-2.0.20221103.3-x86_64-gp2'
+export PACKER_SOURCE_IMAGE_NAME='amzn2-ami-hvm-2.0.20230628.0-x86_64-gp2'
 export PACKER_SSH_USERNAME='ec2-user'
 export PACKER_VOLUME_SIZE=20
 export PACKER_IVY_TAG='ivy'

--- a/providers/amazon/images/ivy-base/packer.env
+++ b/providers/amazon/images/ivy-base/packer.env
@@ -1,2 +1,2 @@
 # ivy-base is special, it bootstraps the builds by building on an existing image
-export PACKER_SOURCE_IMAGE_NAME=amzn2-ami-hvm-2.0.20220218.3-x86_64-gp2
+export PACKER_SOURCE_IMAGE_NAME=amzn2-ami-hvm-2.0.20230628.0-x86_64-gp2


### PR DESCRIPTION
Relates to https://github.com/Over-haul/ami-bakery/pull/49